### PR TITLE
Add validate_max_errors

### DIFF
--- a/app/graphql/app_schema.rb
+++ b/app/graphql/app_schema.rb
@@ -34,4 +34,6 @@ class AppSchema < GraphQL::Schema
     # find an object in your application
     # ...
   end
+
+  validate_max_errors(100)
 end


### PR DESCRIPTION
ref
https://github.com/rmosolgo/graphql-ruby/issues/4154

argumentsにエラーが大量にある場合、すべてのエラーを解析してレスポンスする。
そのためエラーが大量に発生するクエリーをリクエストすることで負荷をかけることができる。

`validate_max_errors(100)`などと設定しておくと、100個エラーがあると残りの解析は行わない。